### PR TITLE
言葉を説明する機能の大枠を実装

### DIFF
--- a/core/exceptions/not-asked-word-question.ts
+++ b/core/exceptions/not-asked-word-question.ts
@@ -1,0 +1,7 @@
+class NotAskedWordQuestion extends Error {
+    constructor() {
+        super("We can only support word questions");
+    }
+}
+
+export default NotAskedWordQuestion;

--- a/core/interfaces/word-explainer.ts
+++ b/core/interfaces/word-explainer.ts
@@ -1,0 +1,9 @@
+import Understanding from "../types/understanding";
+import WordExplanation from "../types/word-explanation";
+
+interface WordExplainerInterface {
+    understand(question: string): Promise<Understanding>;
+    explain(word: string): Promise<WordExplanation>;
+}
+
+export default WordExplainerInterface;

--- a/core/models/teacher.ts
+++ b/core/models/teacher.ts
@@ -1,0 +1,15 @@
+import WordExplainerInterface from "../interfaces/word-explainer";
+import Understanding from "../types/understanding";
+import WordExplanation from "../types/word-explanation";
+
+class Teacher implements WordExplainerInterface {
+    explain(word: string): Promise<WordExplanation> {
+        throw new Error("Method not implemented.");
+    }
+
+    understand(question: string): Promise<Understanding> {
+        throw new Error("Method not implemented.");
+    }
+}
+
+export default Teacher;

--- a/core/models/teacher.ts
+++ b/core/models/teacher.ts
@@ -4,10 +4,12 @@ import WordExplanation from "../types/word-explanation";
 
 class Teacher implements WordExplainerInterface {
     explain(word: string): Promise<WordExplanation> {
+        // TODO: Implement
         throw new Error("Method not implemented.");
     }
 
     understand(question: string): Promise<Understanding> {
+        // TODO: Implement
         throw new Error("Method not implemented.");
     }
 }

--- a/core/package.json
+++ b/core/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "core",
+  "version": "1.0.0",
+  "description": "core domain library for imi-oshie-taro",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/core/services/word-explain-service.ts
+++ b/core/services/word-explain-service.ts
@@ -4,7 +4,7 @@ import WordExplanation from "../types/word-explanation"
 
 class WordExplainService {
     private teacher: WordExplainerInterface
-    __constructor(teacher: WordExplainerInterface) {
+    constructor(teacher: WordExplainerInterface) {
         this.teacher = teacher
     }
 

--- a/core/services/word-explain-service.ts
+++ b/core/services/word-explain-service.ts
@@ -1,0 +1,21 @@
+import NotAskedWordQuestion from "../exceptions/not-asked-word-question"
+import WordExplainerInterface from "../interfaces/word-explainer"
+import WordExplanation from "../types/word-explanation"
+
+class WordExplainService {
+    private teacher: WordExplainerInterface
+    __constructor(teacher: WordExplainerInterface) {
+        this.teacher = teacher
+    }
+
+    async explain(question: string): Promise<WordExplanation> {
+        if (question === "") throw new Error("Empty Question")
+
+        const understanding = await this.teacher.understand(question)
+        if (!understanding.hasAskedWordQuestion) throw new NotAskedWordQuestion()
+
+        return await this.teacher.explain(understanding.askedWord)
+    }
+}
+
+export default WordExplainService

--- a/core/types/understanding.ts
+++ b/core/types/understanding.ts
@@ -1,0 +1,6 @@
+type Understanding = {
+    askedWord: string;
+    hasAskedWordQuestion: boolean;
+};
+
+export default Understanding;

--- a/core/types/word-explanation.ts
+++ b/core/types/word-explanation.ts
@@ -1,0 +1,7 @@
+type WordExplanation = {
+    // TODO: design what the app needs
+    word: string;
+    definition: string;
+};
+
+export default WordExplanation;


### PR DESCRIPTION
# 概要
言葉を説明する処理の流れに関してはこんな感じで行こうと考えてます。
次にLangChainを用いた詳細を実装していくつもりです。

# 説明（処理のながれ）

1. 質問の理解（そもそも、言葉についての質問なのかどうか？）
2. 言葉に関する質問の場合、それを質問

# 背景
今回は、言葉の説明に適した形式のプロンプトのテンプレートを用意するので、あえて質問の内容を理解するために一度GPTに投げています。
また、もし画像生成の機能を入れる場合、そっちが返答のボトルネックになると思うので、2度GPTに問い合わせる処理時間はあまり問題ではないと考えています。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a `Teacher` class that can explain words and understand questions asynchronously.
  - Added a `WordExplainService` for providing word explanations based on given questions.
  - Implemented new types for `Understanding` and `WordExplanation` to standardize data structures.

- **Bug Fixes**
  - Added custom exception handling for unsupported word questions with the `NotAskedWordQuestion` class.

- **Documentation**
  - Updated metadata in `package.json` for better clarity and maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->